### PR TITLE
Bug featured image

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,7 +9,11 @@
             {{ end }}
 
             <div class="{{$post_class}}"
-                 style="background-image: url('{{ $featured_image | absURL}}')">
+                {{ if $featured_image }}
+                    {{ $image := .Resources.GetMatch (.Params.featured_image) }}
+                    style="background-image: url('{{$image.Permalink }}')"
+                {{ end }}
+            >
                 <div class="post-title">
                     {{ .Title }}
                     {{ if .Params.description }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,7 +11,11 @@
             <div class="{{$post_class}}"
                 {{ if $featured_image }}
                     {{ $image := .Resources.GetMatch (.Params.featured_image) }}
+                    {{ if $image }}
                     style="background-image: url('{{$image.Permalink }}')"
+                    {{ else }}
+                    style="background-image: url('{{ $featured_image | absURL}}')"
+                    {{ end }}
                 {{ end }}
             >
                 <div class="post-title">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -24,7 +24,12 @@
                             {{ $image := .Resources.GetMatch (.Params.featured_image) }}
                             <div class="post-item-image-wrapper">
                             <div class="post-item-image"
-                                 style="background-image: url('{{ $image.Permalink }}')"></div>
+                            {{ if $image }}
+                                 style="background-image: url('{{ $image.Permalink }}')"
+                            {{ else }}
+                                 style="background-image: url('{{ $featured_image | absURL}}')"
+                            {{ end }}
+                            ></div>
                             </div>
                         {{ end }}
                     </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -21,9 +21,10 @@
                         </div>
                         {{ $featured_image := .Params.featured_image }}
                         {{ if $featured_image }}
+                            {{ $image := .Resources.GetMatch (.Params.featured_image) }}
                             <div class="post-item-image-wrapper">
                             <div class="post-item-image"
-                                 style="background-image: url('{{$featured_image | relLangURL }}')"></div>
+                                 style="background-image: url('{{ $image.Permalink }}')"></div>
                             </div>
                         {{ end }}
                     </div>


### PR DESCRIPTION
This pull request fixes an issue when featured_image refers to a page resource. Now: if a resource can be found that matches featured_image, it is taken as such; else it does as previously: create an absolute url from the param. The code is not pretty though...