### PR TITLE
Add reading time in home page, hide minute if less than a minute

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -52,7 +52,9 @@
                             {{ $minutes := math.Floor (div $readTime 60) }}
                             {{ $seconds := mod $readTime 60 }}
 
+                            {{ if gt $minutes 0}}
                             {{ $minutes }} {{ cond (eq $minutes 1) "minute" "min" }}
+                            {{ end }}
                             {{ $seconds }} {{ cond (eq $seconds 1) "second" "s" }}.
                         {{ end }}
                     </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,7 +18,7 @@
                             <div class="post-item-meta">
                                 {{ .PublishDate.Format "2006-01-02" }}
                                 &emsp;
-                                <!-- 阅读时间 -->
+                                <!-- Reading Time Start -->
                                 {{ if .Site.Params.enableReadingTime }}
                                 <i class="material-icons" style="font-size:10px">schedule</i>
                                 {{ $readTime := mul (div (countwords .Content) 220.0) 60 }}
@@ -31,6 +31,7 @@
                                 {{ end }}
                                 {{ $seconds }} {{ cond (eq $seconds 1) "second" "s" }}
                                 {{ end }}
+                                <!-- Reading Time End -->
                             </div>
                         </div>
                         {{ $featured_image := .Params.featured_image }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,6 +17,20 @@
                             </div>
                             <div class="post-item-meta">
                                 {{ .PublishDate.Format "2006-01-02" }}
+                                &emsp;
+                                <!-- 阅读时间 -->
+                                {{ if .Site.Params.enableReadingTime }}
+                                <i class="material-icons" style="font-size:10px">schedule</i>
+                                {{ $readTime := mul (div (countwords .Content) 220.0) 60 }}
+
+                                {{ $minutes := math.Floor (div $readTime 60) }}
+                                {{ $seconds := mod $readTime 60 }}
+
+                                {{ if gt $minutes 0}}
+                                {{ $minutes }} {{ cond (eq $minutes 1) "minute" "min" }}
+                                {{ end }}
+                                {{ $seconds }} {{ cond (eq $seconds 1) "second" "s" }}
+                                {{ end }}
                             </div>
                         </div>
                         {{ $featured_image := .Params.featured_image }}


### PR DESCRIPTION
在首页增加了文章的阅读时间，阅读时间少于1分钟则隐藏分钟只显示秒数，不会显示 0 min