### PR TITLE
Extract post-item-title and Add Summary in home page

### DIFF
--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -21,13 +21,7 @@
                             <div class="post-item-title">
                                 {{.Title}}
                             </div>
-                            <div class="post-item-meta">
-                                {{ dateFormat "Jan 2, 2006" .Date }}
-    
-                                {{ if .Draft }}
-                                <span class="draft-label">DRAFT</span>
-                                {{ end }}
-                            </div>
+                            {{ partial "post-item-meta.html" . }}
                         </div>
                     </div>
                 </div>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -18,13 +18,7 @@
                         <div class="post-item-title">
                             {{.Title}}
                         </div>
-                        <div class="post-item-meta">
-                            {{ dateFormat "Jan 2, 2006" .Date }}
-
-                            {{ if .Draft }}
-                            <span class="draft-label">DRAFT</span>
-                            {{ end }}
-                        </div>
+                        {{ partial "post-item-meta.html" . }}
                     </div>
                 </div>
             </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,7 +13,11 @@
                                 {{.Title}}
                             </div>
                             <div class="post-item-summary">
-                                {{.Description}}
+                                {{ if isset .Params "description" }}
+                                {{ .Description }}
+                                {{ else}}
+                                {{ .Summary }}
+                                {{ end }}
                             </div>
                             {{ partial "post-item-meta.html" . }}
                         </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -15,24 +15,7 @@
                             <div class="post-item-summary">
                                 {{.Description}}
                             </div>
-                            <div class="post-item-meta">
-                                {{ .PublishDate.Format "2006-01-02" }}
-                                &emsp;
-                                <!-- Reading Time Start -->
-                                {{ if .Site.Params.enableReadingTime }}
-                                <i class="material-icons" style="font-size:10px">schedule</i>
-                                {{ $readTime := mul (div (countwords .Content) 220.0) 60 }}
-
-                                {{ $minutes := math.Floor (div $readTime 60) }}
-                                {{ $seconds := mod $readTime 60 }}
-
-                                {{ if gt $minutes 0}}
-                                {{ $minutes }} {{ cond (eq $minutes 1) "minute" "min" }}
-                                {{ end }}
-                                {{ $seconds }} {{ cond (eq $seconds 1) "second" "s" }}
-                                {{ end }}
-                                <!-- Reading Time End -->
-                            </div>
+                            {{ partial "post-item-meta.html" . }}
                         </div>
                         {{ $featured_image := .Params.featured_image }}
                         {{ if $featured_image }}

--- a/layouts/partials/post-item-meta.html
+++ b/layouts/partials/post-item-meta.html
@@ -1,0 +1,22 @@
+<div class="post-item-meta">
+    {{ .PublishDate.Format "2006-01-02" }}
+    &emsp;
+    <!-- Reading Time Start -->
+    {{ if .Site.Params.enableReadingTime }}
+    <i class="material-icons" style="font-size:10px">schedule</i>
+    {{ $readTime := mul (div (countwords .Content) 220.0) 60 }}
+
+    {{ $minutes := math.Floor (div $readTime 60) }}
+    {{ $seconds := mod $readTime 60 }}
+
+    {{ if gt $minutes 0}}
+    {{ $minutes }} {{ cond (eq $minutes 1) "minute" "min" }}
+    {{ end }}
+    {{ $seconds }} {{ cond (eq $seconds 1) "second" "s" }}
+    {{ end }}
+    <!-- Reading Time End -->
+    &emsp;
+    {{ if .Draft }}
+    <span class="draft-label">DRAFT</span>
+    {{ end }}
+</div>


### PR DESCRIPTION
1. 把主页、归档、分类等的文章信息抽取到一个partial，统一了日期格式
2. 主页增加了Summary