### PR TITLE
fixed the bug that the favicon could not display normally

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -43,7 +43,7 @@
 {{end}}
 
 {{ if .Site.Params.favicon }}
-<link rel="icon" href="{{ .Site.Params.favicon }}">
+<link rel="icon" href="{{ .Site.Params.favicon | absURL }}">
 <!-- favicon -->
 {{ end }}
 


### PR DESCRIPTION
In the old version, the favicon couldn't display normally after entering the article page, so i fixed the bug.