### PR TITLE
Update head.html with optional canonical url

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -41,10 +41,14 @@
 {{if .Site.Params.manifest}}
 <link rel="manifest" href="{{.Site.Params.manifest}}">
 {{end}}
+  
+{{if .Params.canonicalUrl}}
+<link rel="canonical" href="{{.Params.canonicalUrl}}" />
+{{end}}
 
+<!-- favicon -->
 {{ if .Site.Params.favicon }}
 <link rel="icon" href="{{ .Site.Params.favicon | absURL }}">
-<!-- favicon -->
 {{ end }}
 
 {{ $styles := resources.Get "scss/journal.scss" | toCSS | minify | fingerprint }}


### PR DESCRIPTION
Add an optional canonical URL as a link tag. See [here](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls#expandable-5) for more info regarding this tag. Useful for when reposting an existing article, and pointing to the original.