### PR TITLE
支持valine系统设置默认头像

### DIFF
--- a/layouts/partials/journal.html
+++ b/layouts/partials/journal.html
@@ -99,6 +99,7 @@ app = new Vue({
                 requiredFields: ['nick','mail'],
                 enableQQ: true,
                 recordIP: true,
+                avatar: {{.Site.Params.valine.avator}},
             })
         {{ end }}
         {{ if and (.Site.Params.enableTwikoo) (.IsPage) }}


### PR DESCRIPTION
valine评论系统支持设置默认头像，但是本主题好像没有。

本主题现状是 Gravatar 找不到头像，会显示一个灰色的人头，不太好看。

这个 PR 支持在 `config.toml` 中加入：

```
[params.valine]
avator = "monsterid"
```

来设置自定义默认头像。

<html>
<body>
<!--StartFragment--><p style="box-sizing: border-box; -webkit-tap-highlight-color: transparent; font-family: Consolas, &quot;Liberation Mono&quot;, Menlo, Monaco, &quot;Source Han Sans CN&quot;, &quot;PingFang SC&quot;, &quot;Hiragino Sans GB&quot;, &quot;Microsoft YaHei&quot;, sans-serif; margin: 1.5em 0px; position: relative; color: rgb(51, 51, 51); font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">目前<code style="box-sizing: border-box; -webkit-tap-highlight-color: transparent; font-family: &quot;Fira Code&quot;, Consolas, Monaco, Consolas, monospace, &quot;PingFang SC&quot;, &quot;Hiragino Sans GB&quot;, &quot;Microsoft YaHei&quot;, sans-serif; font-size: 14.4px; font-weight: 400; line-height: 1.5; display: inline-block; padding-left: 2px; padding-right: 2px; vertical-align: baseline; color: rgb(28, 136, 126); background: rgb(243, 243, 243);">非自定义头像</code>有以下7种<code style="box-sizing: border-box; -webkit-tap-highlight-color: transparent; font-family: &quot;Fira Code&quot;, Consolas, Monaco, Consolas, monospace, &quot;PingFang SC&quot;, &quot;Hiragino Sans GB&quot;, &quot;Microsoft YaHei&quot;, sans-serif; font-size: 14.4px; font-weight: 400; line-height: 1.5; display: inline-block; padding-left: 2px; padding-right: 2px; vertical-align: baseline; color: rgb(28, 136, 126); background: rgb(243, 243, 243);">默认值</code>可选:</p>

参数值 | 表现形式 | 备注
-- | -- | --
空字符串'' |   | Gravatar官方图形
mp |   | 神秘人(一个灰白头像)
identicon |   | 抽象几何图形
monsterid |   | 小怪物
wavatar |   | 用不同面孔和背景组合生成的头像
retro |   | 八位像素复古头像
robohash |   | 一种具有不同颜色、面部等的机器人
hide |   | 不显示头像

<!--EndFragment-->
</body>
</html>


![](https://image-1252109614.cos.ap-beijing.myqcloud.com/img/20210509010818.png)