### PR TITLE
hide toc if disableToc is true in front matter

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,6 +1,6 @@
 {{ $headers := findRE "<h[1-4].*?>(.|\n])+?</h[1-4]>" .Content }}
 <!-- at least one header to link to -->
-{{ if ge (len $headers) 1 }}
+{{ if and (not .Params.disableToC) (ge (len $headers) 1) }}
 	<div class="toc-content">
 	<!-- ignore empty links with + -->
 		{{ $h1_n := len (findRE "(.|\n])+?" .Content) }}


### PR DESCRIPTION
如果具体文章头部信息中中禁用了目录功能，则也不显示目录