### PR TITLE
Fix nav-title URL when i18n is enable

### DIFF
--- a/layouts/partials/mobile-header.html
+++ b/layouts/partials/mobile-header.html
@@ -48,7 +48,7 @@
                 menu
             </i>
         </button>
-        <a id="navTitle" class="navbar-brand" href="{{.Site.BaseURL}}">
+        <a id="navTitle" class="navbar-brand" href="{{ "" | absLangURL }}">
             {{.Site.Title}}
         </a>
         {{ if not .Site.Params.disableDarkMode }}
@@ -62,7 +62,7 @@
 </nav>
 <div class="single-column-header-container" id="pageHead"
      v-bind:style="{ transform: 'translateZ(0px) translateY('+.3*scrollY+'px)', opacity: 1-navOpacity }">
-    <a href="{{.Site.BaseURL}}">
+    <a href="{{ "" | absLangURL }}">
         <div class="single-column-header-title">{{.Site.Title}}</div>
         {{ with .Site.Params.subtitle }}
         <div class="single-column-header-subtitle">{{.}}</div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,8 +1,8 @@
 <div id="sideContainer" class="side-container">
     {{ if eq .Title .Site.Title}}
-    <a class="a-block nav-head active" href="{{.Site.BaseURL}}">
+    <a class="a-block nav-head active" href="{{ "" | absLangURL }}">
     {{ else }}
-    <a class="a-block nav-head false" href="{{.Site.BaseURL}}">
+    <a class="a-block nav-head false" href="{{ "" | absLangURL }}">
     {{ end }}
         <div class="nav-title">
             {{.Site.Title}}


### PR DESCRIPTION
## Description

Turns out when you enable i18n using diary theme, the link on the "navigation title" always pointed to the site URL instead of the
language base url. This PR should fix it.

Tested on my local environment as theme. It is also live on [jossemargt.com](http://jossemargt.com) as `layout` overrides.

## How did I test it

1. Enable hugo multilingual support
2. Add content for the languages you want to test
3. `hugo serve --theme diary`
4. On a web browser, open test subject site. ie: `http://localhost/`
5. On a web browser, click on a post
6. On a web browser, click on the brand/title area

**Validation 1**: It *must* redirect to `http://<site>/<language>` instead of the base url `http://<site>/`. ie: `http://localhost:1313/en` 

**Validation 2**: On a mobile display, proceed with the same steps described above. But the following two areas should behave the same way:

1. Brand/title area on the hamburger menu.
2. Brand/title area that appears at the top when you have scrolled down.

## Others

Closes #105