### PR TITLE
Fix link to theme author's website in copyright

### DIFF
--- a/layouts/partials/copyright.html
+++ b/layouts/partials/copyright.html
@@ -1,5 +1,5 @@
 <!-- Please don't remove the information of theme makers. -->
-{{ i18n "hugo_theme" }} <a href="https://github.com/amazingrise/hugo-theme-diary">Diary</a> {{ i18n "by" }} <a href="https://amazingrise.net">Rise</a>
+{{ i18n "hugo_theme" }} <a href="https://github.com/amazingrise/hugo-theme-diary">Diary</a> {{ i18n "by" }} <a href="https://risehere.net/">Rise</a>
 <br>
 {{ i18n "ported_from" }} <a href="https://mak1t0.cc/" target="_blank" rel="noreferrer noopener">Makito</a>'s <a href="https://github.com/SumiMakito/hexo-theme-journal/" target="_blank" rel="noreferrer noopener">Journal.</a> <br>
 <br>


### PR DESCRIPTION
Started using your theme (many thanks!), but noticed that https://amazingrise.net/ in the copyright section is not working anymore, the link is dead. The correct link now seems to be https://risehere.net/, taken from your GitHub profile. I swapped the URL so that attribution is as correct as possible.