### PR TITLE
 fix a Gitalk error "Container not found"

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -94,7 +94,7 @@
   <script src="{{"/js/toc.js" | relURL}}"></script>
 {{ end }}
 
-{{ if and (.Site.Params.enableGitalk) (.IsPage) }}
+{{ if and ( and ( .Site.Params.enableGitalk ) ( .IsPage ) ) ( or ( not ( isset .Params "comment" ) ) ( eq .Params.comment true ) ) }}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.css">
 <script src="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js"></script>
 <script src="{{"/vendor/js/md5.min.js" | relURL}}"></script>


### PR DESCRIPTION
If not, the error will be output to the console when **comment** is set to **false** in _front matter_.