### PR TITLE
assets/scss: allow line highlighting inside pre tags

### DIFF
--- a/assets/scss/dark-mode.scss
+++ b/assets/scss/dark-mode.scss
@@ -42,7 +42,7 @@ body.night {
 
   pre {
     code:not([data-lang]) {
-      background: none !important;
+      background: none;
       color: $dark-mode-text !important;
     }
     color: $dark-mode-text !important;

--- a/assets/scss/journal.scss
+++ b/assets/scss/journal.scss
@@ -145,7 +145,7 @@ pre {
   border-radius: 5px;
   font-family: $mono-font-list;
   * {
-    background: none !important;
+    background: none;
     font-family: $mono-font-list !important;
   }
   code {

--- a/assets/scss/journal.scss
+++ b/assets/scss/journal.scss
@@ -131,7 +131,7 @@ button {
 
 code {
   color: $dark-accent;
-  background: rgba($color-accent, 0.07) !important;
+  background: rgba($color-accent, 0.07);
   padding: 2px 5px;
   border-radius: 3px;
   font-family: $mono-font-list;


### PR DESCRIPTION
Currently the background color used either of the light or dark themes on the `pre` tags overrides the line highlighting applied as part of the syntax highlighting as seen in the example in:
https://gohugo.io/content-management/syntax-highlighting/#highlighting-in-code-fences

This changes allows line highlighting.