### PR TITLE
Add Cusdis support

### DIFF
--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -107,7 +107,6 @@ twikoo.init({
   data-page-url="{{ .Permalink }}"
   data-page-title="{{ .Title }}"
   data-theme="auto"
-  <!-- Automatically set theme by prefers-color-scheme -->
 ></div>
 <script async defer src="https://cusdis.com/js/cusdis.es.js"></script>
 {{ end }}

--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -98,3 +98,14 @@ twikoo.init({
         async>
 </script>
 {{ end }}
+
+{{ if .Site.Params.cusdisAppID }}
+<div id="cusdis_thread"
+  data-host="https://cusdis.com"
+  data-app-id="{{ .Site.Params.cusdisAppID }}"
+  data-page-id="{{ .File.UniqueID }}"
+  data-page-url="{{ .Permalink }}"
+  data-page-title="{{ .Title }}"
+></div>
+<script async defer src="https://cusdis.com/js/cusdis.es.js"></script>
+{{ end }}

--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -106,6 +106,8 @@ twikoo.init({
   data-page-id="{{ .File.UniqueID }}"
   data-page-url="{{ .Permalink }}"
   data-page-title="{{ .Title }}"
+  data-theme="auto"
+  <!-- Automatically set theme by prefers-color-scheme -->
 ></div>
 <script async defer src="https://cusdis.com/js/cusdis.es.js"></script>
 {{ end }}


### PR DESCRIPTION
Cusdis is Open-source, lightweight, privacy-friendly alternative to Disqus.
If you want to enable it,Edit your config.toml in the hugo website's root directory.
Add the following line to the section [params]
`cusdisAppID = "Your App ID"`
The App ID can be found at the end of the url of the dashboard or in the Embed Code button.