### PR TITLE
修复Disqus参数导致的评论不加载的问题

### DIFF
--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -11,7 +11,7 @@
      */
     var disqus_config = function () {
         // Replace PAGE_URL with your page's canonical URL variable
-        this.page.url = '{{ .RelPermalink }}';  
+        this.page.url = '{{ .Permalink }}';  
         
         // Replace PAGE_IDENTIFIER with your page's unique identifier variable
         this.page.identifier = '{{ .RelPermalink }}'; 


### PR DESCRIPTION
Disqus的参数`page.url`需要不能是相对路径，不然不工作

参考文档：https://help.disqus.com/en/articles/1717301-i-m-receiving-the-message-we-were-unable-to-load-disqus#incorrectly-formatted-javascript-configuration-variables
文档里相关描述：
```
this.page.url must use an absolute URL; relative URLs won’t work. E.g., 
 Good — absolute URL: this.page.url = 'http://example.com/article/1/'; 
 Bad — relative URL: this.page.url = '/article/1/';
```
