### PR TITLE
Fixed: Giscus param (data_repo_id) naming error.

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -50,7 +50,7 @@ theme="github-light"
 # Please visit https://giscus.app/ to generate settings.
 [params.giscus]
     data_repo="username/repo"
-    data-repo-id="**************************"    
+    data_repo_id="**************************"    
     data_category="General"
     data_category_id="*********************"
     data_mapping="pathname"


### PR DESCRIPTION
Diary supports [Giscus](https://giscus.app/) as the comment system.
But there was an error reading the value of config item: `data-repo-id`.

File: `layouts/partials/comment.html`:
``` html
{{ if .Site.Params.enableGiscus }}
<script src="https://giscus.app/client.js"
        data-repo="{{ .Site.Params.giscus.data_repo}}"
        data-repo-id="{{ .Site.Params.giscus.data_repo_id}}"
        data-category="{{ .Site.Params.giscus.data_category}}"
        data-category-id="{{ .Site.Params.giscus.data_category_id}}"
        data-mapping="{{ .Site.Params.giscus.data_mapping}}"
        data-strict="{{ .Site.Params.giscus.data_strict}}"
        data-reactions-enabled="{{ .Site.Params.giscus.data_reactions_enabled}}"
        data-emit-metadata="{{ .Site.Params.giscus.data_emit_metadata}}"
        data-input-position="{{ .Site.Params.giscus.data_input_position}}"
        data-theme="{{ .Site.Params.giscus.data_theme}}"
        data-lang="{{ .Site.Params.giscus.data_lang}}"
        crossorigin="{{ .Site.Params.giscus.crossorigin}}"
        async>
</script>
{{ end }}
```

File: `exampleSite/config.toml`:
```toml
# Please visit https://giscus.app/ to generate settings.
[params.giscus]
    data_repo="username/repo"
    data_repo_id="**************************"    
    data_category="General"
    data_category_id="*********************"
    data_mapping="pathname"
    data_strict="0"
    data_reactions_enabled="1"
    data_emit_metadata="0"
    data_input_position="bottom"
    data_theme="preferred_color_scheme"
    data_lang="en"
    crossorigin="anonymous"
```

Now changed to `data_repo_id` to follow the naming rules in the file `config.toml`. 
You can easily copy the settings to your own site.