### PR TITLE
Corrected the example config's location

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ hugo server --themesDir ../..
 
 ### Example config
 
-See [/exampleSite/config.toml](https://github.com/AmazingRise/hugo-theme-diary/blob/master/exampleSite/config.toml)
+See [/exampleSite/config.toml](https://github.com/AmazingRise/hugo-theme-diary/blob/main/exampleSite/config.toml)
 
 ### Customization
 


### PR DESCRIPTION
This pull request changes the link of the example config from the old [one](https://github.com/AmazingRise/hugo-theme-diary/blob/master/exampleSite/config.toml) to the correct branch, which is [main](https://github.com/AmazingRise/hugo-theme-diary/blob/main/exampleSite/config.toml). 

