### PR TITLE
Add new CopyrightHtml parameter

### DIFF
--- a/layouts/partials/copyright.html
+++ b/layouts/partials/copyright.html
@@ -4,9 +4,13 @@
 {{ i18n "ported_from" }} <a href="https://mak1t0.cc/" target="_blank" rel="noreferrer noopener">Makito</a>'s <a href="https://github.com/SumiMakito/hexo-theme-journal/" target="_blank" rel="noreferrer noopener">Journal.</a> <br>
 <br>
 <!-- Because this project is under MIT licence. -->
+	{{ with .Site.Params.CopyrightHtml }}
+	{{ . | safeHTML }}
+    {{ else }}
 &copy;
-	{{ if .Site.Copyright }}
+    {{ if .Site.Copyright }}
 	{{ .Site.Copyright }}
 	{{ else }}
 	{{.Site.Home.Date.Year}} {{.Site.Title}}
 	{{ end }}
+    {{ end }}


### PR DESCRIPTION
.Site.Param.CopyhightHtml supersede .Site.Copyright if set, allowing the end user to use HTML tags in the copyright notice, to include links and images.

This setting enable the use the HTML copyright notice generated by https://chooser-beta.creativecommons.org/, see example below

![copyright notice html](https://github.com/AmazingRise/hugo-theme-diary/assets/6175852/273647c3-e91f-4ce5-846c-0a5fdd234990)