### PR TITLE
Add support for .Summary

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -12,7 +12,11 @@
                                 {{.Title}}
                             </div>
                             <div class="post-item-summary">
-                                {{.Description}}
+                                {{ if .Description }}
+                                    {{ .Description }}
+                                {{ else }}
+                                    {{ .Summary }}
+                                {{ end }}
                             </div>
                             {{ partial "post-item-meta.html" . }}
                         </div>


### PR DESCRIPTION
Add support for .Summary in [offical post](https://gohugo.io/content-management/summaries/) and won't affect the original use of `description`.

The check logic lies here:

1. Have `description` value?
2. Have `summary` value?
3. Have `<!--more-->` tag?
4. And finally generate the summary with the first 70 characters.

Associated with issue #165 