### PR TITLE
fix: compatibility with Hugo version 0.123 and later

### DIFF
--- a/layouts/partials/extrabar.html
+++ b/layouts/partials/extrabar.html
@@ -25,7 +25,7 @@
             </span>
         </a>
         {{ end }}
-        {{ if and (.Paginator) (not (.Data.Terms)) }}
+        {{ if and (.Page.IsNode) (.Page.Paginator) (not (.Data.Terms)) }}
         {{ if gt .Paginator.TotalPages 1 }}
 
         <a class="pagination-action" {{ if .Paginator.HasPrev }} href="{{.Paginator.Prev.URL}}">

--- a/layouts/partials/mobile-paginator.html
+++ b/layouts/partials/mobile-paginator.html
@@ -1,4 +1,4 @@
-{{ if and (.Paginator) (not (.Data.Terms)) }}
+{{ if and (.Page.IsNode) (.Page.Paginator) (not (.Data.Terms)) }}
 {{ if gt .Paginator.TotalPages 1 }}
 <div class="pagination">
     {{ if .Paginator.HasPrev }}


### PR DESCRIPTION
Hugo site build (using version 0.123.3) was failing below error message. This is due to a change in Hugo itself, see ref.
Backward compatibility confirmed using Hugo version 0.122.0
Forward compatibility confirmed using Hugo version 0.124.1 (latest as of now)

```
ERROR render of "page" failed: ".../themes/diary/layouts/_default/baseof.html:15:16": execute of template failed: template: _default/single.html:15:16: executing "_default/single.html" at <partial "extrabar.html" .>: error calling partial: ".../themes/diary/layouts/partials/extrabar.html:28:19": execute of template failed: template: partials/extrabar.html:28:19: executing "partials/extrabar.html" at <.Paginator>: error calling Paginator: pagination not supported for this page: kind: "page", path: "...", file: "..."
```

Ref: https://github.com/AmazingRise/hugo-theme-diary/issues/177
Ref: https://github.com/gohugoio/hugo/issues/12080

@shinyzhu Could you please kindly review and merge?