### PR TITLE
Fix Google Analytics Warning Issue

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -4,7 +4,11 @@ languageCode = "en-us"
 title = "A Hugo Site"
 copyright = "This is a customized copyright."
 theme = "diary"
-# googleAnalytics = "UA-123-45"
+
+#Google Analytics
+[services]
+  [services.googleAnalytics]
+    id = "G-XXXXXXXXXX"  # Your Google Analytics ID
 
 [markup]
   [markup.highlight]

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,7 +8,7 @@
 
 <meta charset="utf-8">
 <meta name="X-UA-Compatible" content="IE=edge">
-<meta name="google-site-verification" content="{{ .Site.Params.googleSiteVerification }}">
+<meta name="google-site-verification" content="{{ .Site.Config.Services.GoogleAnalytics.ID }}">
 <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport">
 <meta content="telephone=no" name="format-detection">
 <meta name="description" content="{{ $description }}">
@@ -27,7 +27,7 @@
 
 <!-- metadata -->
 
-{{ if .Site.GoogleAnalytics }}
+{{ if .Site.Config.Services.GoogleAnalytics.ID }}
 {{ template "_internal/google_analytics.html" . }}
 {{ end }}
 


### PR DESCRIPTION
Updated the Google Analytics configuration to use the new `.Site.Config.Services.GoogleAnalytics.ID` parameter as the old `.Site.GoogleAnalytics` is deprecated in Hugo v0.120.0 and will be removed in a future release.

<img width="1011" alt="image" src="https://github.com/user-attachments/assets/63aafcf5-eeee-4438-9519-062a2c7cac9a">

### after⬇️

<img width="957" alt="image" src="https://github.com/user-attachments/assets/0126aadb-562b-4451-adc7-9e5f9e1b54af">
