### PR TITLE
Added sitemap configuration to config.toml

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -7,7 +7,7 @@ theme = "diary"
 
 # Generate sitemap in the public folder
 [sitemap]
-  changefreq = "daily"
+  changefreq = "always"
   filename = "sitemap.xml"
   priority = 0.5
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,7 +5,13 @@ title = "A Hugo Site"
 copyright = "This is a customized copyright."
 theme = "diary"
 
-#Google Analytics
+# Generate sitemap in the public folder
+[sitemap]
+  changefreq = "daily"
+  filename = "sitemap.xml"
+  priority = 0.5
+
+# Google Analytics
 [services]
   [services.googleAnalytics]
     id = "G-XXXXXXXXXX"  # Your Google Analytics ID


### PR DESCRIPTION
Enhance sitemap configuration to make it easier for bloggers to expose their sites to search engines.
<img width="741" alt="image" src="https://github.com/user-attachments/assets/a4cc4057-895e-46f0-931f-bbf925bb83cf">
