### PR TITLE
Update user-scalable to 5 for accessibility

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,7 +9,7 @@
 <meta charset="utf-8">
 <meta name="X-UA-Compatible" content="IE=edge">
 <meta name="google-site-verification" content="{{ .Site.Config.Services.GoogleAnalytics.ID }}">
-<meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport">
+<meta content="width=device-width, initial-scale=1.0, maximum-scale=5, user-scalable=5" name="viewport">
 <meta content="telephone=no" name="format-detection">
 <meta name="description" content="{{ $description }}">
 <meta name="renderer" content="webkit">


### PR DESCRIPTION
It is difficult to view images on mobile because pinch zoom is not available. I hope this PR will be reviewed and merged

If you want to test it on the desktop web browser, refer to [this Stack Overflow answer](https://stackoverflow.com/questions/58657004/pinch-zoom-in-a-web-page-in-chrome-dev-tools). @AmazingRise 

![Screencast 2024-09-08 12-13-52](https://github.com/user-attachments/assets/8807ebab-3538-4480-ade5-706bae6ed090)

_Test [my blog post](https://markruler.github.io/posts/network/ip-geolocation/)_

![image](https://github.com/user-attachments/assets/a233c939-070e-409b-b4e4-99e144d84035)
