### PR TITLE
Support multiline for .Site.Params.subtitle

### DIFF
--- a/layouts/partials/mobile-header.html
+++ b/layouts/partials/mobile-header.html
@@ -64,7 +64,7 @@
      v-bind:style="{ transform: 'translateZ(0px) translateY('+.3*scrollY+'px)', opacity: 1-navOpacity }">
     <a href="{{ "" | absLangURL }}">
         <div class="single-column-header-title">{{.Site.Title}}</div>
-        {{ with .Site.Params.subtitle }}
+        {{ range .Site.Params.subtitle }}
         <div class="single-column-header-subtitle">{{.}}</div>
         {{ end }}
 

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -7,7 +7,7 @@
         <div class="nav-title">
             {{.Site.Title}}
         </div>
-        {{ with .Site.Params.subtitle }}
+        {{ range .Site.Params.subtitle }}
         <div class="nav-subtitle">
             {{.}}
         </div>


### PR DESCRIPTION
This PR add multiline support for .Site.Params.subtitle, which is also supported by the [original hexo theme](https://github.com/SumiMakito/hexo-theme-journal/?tab=readme-ov-file#title-and-subtitle)

Since rendering raw HTML code is not allowed in hugo, this PR changes `params.subtile` to a list, and use `range` to render texts. But a string type is still ok, at least in `v0.135.0` I have tested.