### PR TITLE
feat: supports markdown alert syntax

### DIFF
--- a/assets/scss/dark-mode.scss
+++ b/assets/scss/dark-mode.scss
@@ -24,6 +24,10 @@ body.night {
     }
   }
 
+  blockquote.alert-diary {
+    background: $dark-mode-front-container-background;
+  }
+
   a {
     color: $light-accent;
     &:hover {

--- a/assets/scss/journal.scss
+++ b/assets/scss/journal.scss
@@ -173,6 +173,53 @@ blockquote {
   }
 }
 
+blockquote.alert-diary {
+  background: $front-container-background;
+  padding-left: 15px;
+
+  .alert-heading {
+    display: flex;
+    align-items: center;
+    font-size: $post-subtitle-size;
+    margin-bottom: 10px;
+  }
+
+  .material-icons {
+    padding-right: 4px;
+  }
+}
+
+@mixin alert-color($color) {
+  border-left-color: $color;
+  .alert-heading {
+    color: $color !important;
+  }
+
+  .material-icons {
+    color: $color !important;
+  }
+}
+
+blockquote.alert-diary-important {
+  @include alert-color(#8250df);
+}
+
+blockquote.alert-diary-tip {
+  @include alert-color(#1a7f37);
+}
+
+blockquote.alert-diary-caution {
+  @include alert-color(#d1242f);
+}
+
+blockquote.alert-diary-note {
+  @include alert-color($color-accent);
+}
+
+blockquote.alert-diary-warning {
+  @include alert-color(#9a6700);
+}
+
 a {
   color: $color-accent;
   &:hover {

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -26,3 +26,13 @@
   translation: 草稿
 - id: toc_title
   translation: 目录
+- id: caution
+  translation: 注意
+- id: important
+  translation: 重要
+- id: note
+  translation: 笔记
+- id: tip
+  translation: 提示
+- id: warning
+  translation: 警告

--- a/layouts/_markup/render-blockquote.html
+++ b/layouts/_markup/render-blockquote.html
@@ -1,0 +1,25 @@
+{{ $icons := dict
+  "caution" "report_gmailerrorred"
+  "important" "priority_high"
+  "note" "info_outline"
+  "tip" "lightbulb_outline"
+  "warning" "warning_amber"
+}}
+
+{{ if eq .Type "alert" }}
+  <blockquote class="alert-diary alert-diary-{{ .AlertType }}">
+    <p class="alert-heading">
+    <span class="material-icons">{{ index $icons .AlertType }}</span>
+      {{ with .AlertTitle }}
+        {{ . }}
+      {{ else }}
+        {{ or (i18n .AlertType) (title .AlertType) }}
+      {{ end }}
+    </p>
+    {{ .Text }}
+  </blockquote>
+{{ else }}
+  <blockquote>
+    {{ .Text }}
+  </blockquote>
+{{ end }}


### PR DESCRIPTION
fixes https://github.com/AmazingRise/hugo-theme-diary/issues/200

preview:
<img width="1224" height="728" alt="image" src="https://github.com/user-attachments/assets/070f8ab9-ffaa-430b-8f9f-bd3d9eb9646b" />
<img width="1166" height="712" alt="image" src="https://github.com/user-attachments/assets/a8d212b3-d391-42ad-a411-144484bd2b73" />

