### PR TITLE
Fix RSS template build failure and language deprecation on Hugo 0.156+

### DIFF
--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -4,10 +4,11 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <generator>Hugo -- gohugo.io</generator>{{ if ge hugo.Version "0.158.0" }}{{ with site.Language.Locale }}
+    <language>{{.}}</language>{{ end }}{{ else }}{{ with site.Language.LanguageCode }}
+    <language>{{.}}</language>{{ end }}{{ end }}{{ with site.Params.author }}{{ with .email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .email }}
+    <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
@@ -19,7 +20,7 @@
         <title>{{ .Title }}</title>
         <link>{{ .Permalink }}</link>
         <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-        {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+        {{ with site.Params.author }}{{ with .email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}{{end}}
         <guid>{{ .Permalink }}</guid>
         <description>{{ .Site.Title }} {{ .Permalink }} - {{- .Content | html -}} - {{ .Permalink }} - {{.Site.Copyright}}</description>
         </item>


### PR DESCRIPTION
## Problem

`layouts/index.rss.xml` has two issues that prevent clean RSS rendering on modern Hugo:

### 1. Build failure on Hugo >= 0.156

`.Site.Author.email` and `.Site.Author.name` were deprecated in Hugo v0.124.0 ([gohugoio/hugo#12228](https://github.com/gohugoio/hugo/issues/12228), [#12234](https://github.com/gohugoio/hugo/pull/12234)) and removed from the `Site` type in v0.156.0 ([commit af5051e7](https://github.com/gohugoio/hugo/commit/af5051e759f5de8b7c0520b7f2f7dbbedb798551)). On any Hugo >= 0.156 the build now fails:

```
ERROR error building site: render: failed to render pages:
render of "/" failed: "...themes/diary/layouts/index.rss.xml:8:50":
execute of template failed: template: index.rss.xml:8:50:
executing "index.rss.xml" at <.Site.Author.email>:
can't evaluate field Author in type page.Site
```

This affects **every** site using the theme on Hugo >= 0.156, regardless of whether the user has author info configured — Go templates cannot guard against a field that no longer exists on the type, so even `{{ with .Site.Author.email }}` errors out.

### 2. Deprecation warning on Hugo >= 0.158

The `<language>` block uses `.Site.LanguageCode`, a shortcut that delegates internally to `.Language.LanguageCode`. The latter was deprecated in v0.158.0 in favour of [`.Language.Locale`](https://gohugo.io/methods/site/language/#locale), introduced in the same release. Both return a BCP 47 language tag. Builds on Hugo >= 0.158 emit:

```
WARN deprecated: .Language.LanguageCode was deprecated in Hugo v0.158.0
and will be removed in a future release. Use .Language.Locale instead.
```

## Fix

Migrate to APIs that work on every Hugo release the theme aims to support:

| Old (current upstream) | New (this PR) |
| --- | --- |
| `.Site.Author.email` | `.Site.Params.author.email` |
| `.Site.Author.name` | `.Site.Params.author.name` |
| `.Site.LanguageCode` | `site.Language.Locale` &nbsp;&nbsp;(Hugo >= 0.158) <br>`site.Language.LanguageCode` &nbsp;(Hugo < 0.158) |

The language-tag emission uses an `{{ if ge hugo.Version "0.158.0" }}` branch so only one API is referenced per Hugo version. Naive alternatives — `{{ with or .Locale .LanguageCode }}` or `{{ with cond ... .Locale .LanguageCode }}` — don't work, because Go templates' `or` and `cond` are functions that eagerly evaluate every argument and so cannot short-circuit field access. Only an `{{ if }} ... {{ else }}` block leaves one branch un-executed. Result: **no deprecation warnings on >= 0.158, no template errors on 0.156–0.157** (where `.Locale` does not yet exist).

## What theme users need to do

**Author change** — one-time config update if you currently have `[author]` at the root of your `config.toml`. Move it under `[params]`:

```toml
# before
[author]
  name  = "..."
  email = "..."

# after
[params.author]
  name  = "..."
  email = "..."
```

Users who never configured `[author]` see no behavioural change.

**Language change** — no user action required. The template change is internal; Hugo reads your existing `languageCode = "..."` (or, on newer Hugo, `locale = "..."`) project config key and surfaces it through both the old and new template APIs transparently.

## Tested

Hugo extended **0.161.1** on Linux/amd64 (GitHub Actions, Cloudflare Pages). Build passes with no warnings related to this template; previously failed with the build error quoted above and emitted the language deprecation warning.

Diff: ~7 line changes in a single file (`layouts/index.rss.xml`).
